### PR TITLE
fixed missing Handlebars, Clipboard variables

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,9 @@ define(function(require){
 		methodsGenerator = {},
 		domProps = [];
 		animation = true;
+	
+	var Handlebars = require('handlebars');
+    var Clipboard = require('clipboard');
 
 	var app = {
 		name: 'apiexplorer',


### PR DESCRIPTION
I'm not sure if this is the best way to fix this as javascript isn't my speciality. However trying to use the latest version of apiexplorer from your repo was giving me errors in the JS Console.  Both `Handlebars` and `Clipboard` were missing and the app was failing to load.

Making this change fixed the problems for us, so I thought I'd contribute this back.

Thanks
